### PR TITLE
Improve cleanup commands

### DIFF
--- a/de.desy.constellation.yml
+++ b/de.desy.constellation.yml
@@ -13,7 +13,12 @@ finish-args:
 cleanup:
   - /include
   - /lib/pkgconfig
+  - /share/man
   - /share/pkgconfig
+  - /lib/python3.*/*/*/tests
+  - /lib/python3.*/*/*/*/tests
+  - "*.la"
+  - "*.a"
 modules:
   - pypi-dependencies.json
   - name: Constellation


### PR DESCRIPTION
- Improve cleanup commands to reduce the Flatpak size
- Drop Python tests to reduce the Module sizes

The installed size was reduced from 188.6 MB to 134.3 MB.

**This is just a test PR for maintainers.** 
